### PR TITLE
Add a default for the source path

### DIFF
--- a/lib/get_partial_page.js
+++ b/lib/get_partial_page.js
@@ -3,7 +3,7 @@
 var pathFn = require('path');
 
 module.exports = function (ctx, name) {
-  var source = ctx.page.source,
+  var source = ctx.page.source || './',
       page_path,
       page;
 


### PR DESCRIPTION
Hi! 

I've discovered that this plugin stopped working. I debugged a bit and seems like the context from hexo doesn't have the source path anymore.

With this change, I was able to make it work again. 